### PR TITLE
Added the Symphony Artifactory snapshot/non-snapshot libs repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,40 @@
 	</plugins>
   </build>
 
+  	<repositories>
+                <repository>
+                    <id>symphony</id>
+                    <name>symphony releases</name>
+                    <url>https://repo.symphony.com/artifactory/libs-release</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>snapshots</id>
+                    <url>https://repo.symphony.com/artifactory/libs-snapshot</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>symphony</id>
+                    <name>plugins-release</name>
+                    <url>https://repo.symphony.com/artifactory/plugins-release</url>
+                </pluginRepository>
+                <pluginRepository>
+                    <snapshots />
+                    <id>snapshots</id>
+                    <name>plugins-snapshot</name>
+                    <url>https://repo.symphony.com/artifactory/plugins-snapshot</url>
+                </pluginRepository>
+            </pluginRepositories>
+
   <reporting>
 	<plugins>
 		<plugin>


### PR DESCRIPTION
So that the build will look/pull the dependencies from the Symphony Artifactory repositories first.