### PR TITLE
Fix repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,9 +155,11 @@
                         <enabled>false</enabled>
                     </snapshots>
                 </repository>
+
                 <repository>
                     <id>snapshots</id>
-                    <url>https://repo.symphony.com/artifactory/libs-snapshot</url>
+					<!-- This fix was need because the protoc-jar is being published on plugins-snapshot-local -->
+                    <url>https://repo.symphony.com/artifactory/plugins-snapshot-local</url>
                     <releases>
                         <enabled>false</enabled>
                     </releases>


### PR DESCRIPTION
This was needed because of change made to the way proto-jar is published to artifactory.